### PR TITLE
[REFACTOR] css & 도메인 하위 컴포넌트 생성

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -21,7 +21,6 @@
   "rules": {
     "react-hooks/rules-of-hooks": "error",
     "react-hooks/exhaustive-deps": "warn",
-    "no-undef": "off",
     "react/jsx-uses-react": "off",
     "react/react-in-jsx-scope": "off",
     "@emotion/pkg-renaming": "error",

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "module": "ES6",
     "jsx": "preserve",
     "paths": {
       "@assets/*": ["./src/assets/*"],

--- a/src/components/Common/Layout.jsx
+++ b/src/components/Common/Layout.jsx
@@ -13,9 +13,6 @@ const Container = styled.div`
 
 const Inner = styled.div`
   padding: 50px 20px 70px 20px;
-  display: flex;
-  flex-direction: column;
-  height: 100vh;
 `;
 
 const widthStyle = css`

--- a/src/components/My/Intro/Infos.jsx
+++ b/src/components/My/Intro/Infos.jsx
@@ -1,0 +1,48 @@
+import { css } from '@emotion/react';
+import { color } from '@styles/common';
+import { Link } from 'react-router-dom';
+
+const infos = [
+  { name: '포인트', iconUrl: '/icon/point.png', linkUrl: '' },
+  { name: '쿠폰함', iconUrl: '/icon/coupon.png', linkUrl: '' },
+  { name: '선물함', iconUrl: '/icon/gift.png', linkUrl: '' },
+  { name: '찜', iconUrl: '/icon/like.png', linkUrl: '' },
+  { name: '주문내역', iconUrl: '/icon/order.png', linkUrl: '' },
+  { name: '리뷰관리', iconUrl: '/icon/review.png', linkUrl: '' }
+];
+
+const infoCss = {
+  wrap: css`
+    display: grid;
+    grid-template-columns: 1fr 1fr 1fr;
+    grid-gap: 1px;
+  `,
+  section: css`
+    background-color: ${color.white};
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    padding: 15px;
+    gap: 5px;
+  `,
+  text: css`
+    width: 40px;
+  `
+};
+
+const Infos = () => (
+  <div css={infoCss.wrap}>
+    {infos.map((info) => (
+      <Link key={info.name} to={info.linkUrl}>
+        <div css={infoCss.section}>
+          <span css={infoCss.text}>
+            <img src={info.iconUrl} alt={info.name} />
+          </span>
+          <span>{info.name}</span>
+        </div>
+      </Link>
+    ))}
+  </div>
+);
+
+export default Infos;

--- a/src/components/My/Intro/MemberShip.jsx
+++ b/src/components/My/Intro/MemberShip.jsx
@@ -1,0 +1,40 @@
+import { css } from '@emotion/react';
+import { color } from '@styles/common';
+import PropTypes from 'prop-types';
+
+const membershipCss = {
+  wrap: css`
+    display: flex;
+    padding: 5px 15px;
+    align-items: center;
+    justify-content: space-between;
+    background-color: ${color.white};
+    margin-bottom: 2px;
+  `,
+  text: css`
+    width: 200px;
+  `,
+  button: css`
+    background-color: #f6f6f6;
+    padding: 5px 10px;
+    border-radius: 25px;
+    height: 30px;
+    color: #505050;
+  `
+};
+
+const Membership = ({ name, imageUrl }) => (
+  <div css={membershipCss.wrap}>
+    <span css={membershipCss.text}>
+      <img src={imageUrl} alt={`${name} 출두요~!`} />
+    </span>
+    <button css={membershipCss.button}>등급별 혜택</button>
+  </div>
+);
+
+Membership.propTypes = {
+  name: PropTypes.string,
+  imageUrl: PropTypes.string
+};
+
+export default Membership;

--- a/src/components/My/Intro/Profile.jsx
+++ b/src/components/My/Intro/Profile.jsx
@@ -1,0 +1,58 @@
+import { RightOutlined } from '@ant-design/icons';
+import { css } from '@emotion/react';
+import { color } from '@styles/common';
+import PropTypes from 'prop-types';
+
+const profileCss = {
+  wrap: css`
+    display: flex;
+    align-items: center;
+    padding: 15px;
+    gap: 15px;
+    background-color: ${color.white};
+    margin-bottom: 2px;
+    cursor: pointer;
+  `,
+  image: css`
+    width: 60px;
+    height: 60px;
+    border-radius: 50%;
+    overflow: hidden;
+  `,
+  text: css`
+    font-size: 20px;
+    strong {
+      color: ${color.darkGrayText};
+    }
+  `,
+  button: css`
+    position: absolute;
+    right: 15px;
+    font-size: 18px;
+    font-weight: 200;
+    color: ${color.darkGrayText};
+  `
+};
+
+const Profile = ({ nickname, membership, profileUrl }) => (
+  <div css={profileCss.wrap}>
+    <div css={profileCss.image}>
+      <img src={profileUrl} alt={`${nickname}님`} />
+    </div>
+    <span css={profileCss.text}>
+      <strong>{membership}, </strong>
+      {nickname}
+    </span>
+    <span css={profileCss.button}>
+      <RightOutlined />
+    </span>
+  </div>
+);
+
+Profile.propTypes = {
+  nickname: PropTypes.string,
+  membership: PropTypes.string,
+  profileUrl: PropTypes.string
+};
+
+export default Profile;

--- a/src/components/My/Intro/SideInfos.jsx
+++ b/src/components/My/Intro/SideInfos.jsx
@@ -1,0 +1,49 @@
+import { RightOutlined } from '@ant-design/icons';
+import { css } from '@emotion/react';
+import { color } from '@styles/common';
+import { Link } from 'react-router-dom';
+
+const sideInfos = [
+  { name: '공지사항', linkUrl: '' },
+  { name: '이벤트', linkUrl: '' },
+  { name: '고객센터', linkUrl: '' },
+  { name: '환경설정', linkUrl: '' },
+  { name: '약관 및 정책', linkUrl: '' }
+];
+
+const infoCss = {
+  wrap: css`
+    background-color: ${color.white};
+    > div:not(:last-of-type) {
+      border-bottom: 1px solid ${color.lightGrayBg};
+    }
+  `,
+  section: css`
+    padding: 20px 15px;
+    cursor: pointer;
+  `,
+  button: css`
+    position: absolute;
+    right: 15px;
+    font-size: 18px;
+    font-weight: 200;
+    color: ${color.darkGrayText};
+  `
+};
+
+const SideInfos = () => (
+  <div css={infoCss.wrap}>
+    {sideInfos.map((sideInfo) => (
+      <div key={sideInfo.name} css={infoCss.section}>
+        <Link to={sideInfo.linkUrl}>
+          <span>{sideInfo.name}</span>
+          <span css={infoCss.button}>
+            <RightOutlined />
+          </span>
+        </Link>
+      </div>
+    ))}
+  </div>
+);
+
+export default SideInfos;

--- a/src/components/My/Intro/index.js
+++ b/src/components/My/Intro/index.js
@@ -1,0 +1,6 @@
+import Profile from './Profile';
+import Membership from './MemberShip';
+import Infos from './Infos';
+import SideInfos from './SideInfos';
+
+export { Profile, Membership, Infos, SideInfos };

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -122,6 +122,10 @@ const Home = () => {
           address="It's alright~ 우리집으로 가자~"
         />
       }
+      innerStyle={css`
+        display: flex;
+        flex-direction: column;
+      `}
       footer={false}
     >
       <OrderWrap>

--- a/src/pages/My.jsx
+++ b/src/pages/My.jsx
@@ -1,35 +1,35 @@
-import { Link } from 'react-router-dom';
-import styled from '@emotion/styled';
-import { css } from '@emotion/react';
-import PropTypes from 'prop-types';
-import { RightOutlined } from '@ant-design/icons';
 import Layout from '@components/Common/Layout';
 import { color } from '@styles/common';
+import { css } from '@emotion/react';
+import { Infos, Membership, Profile, SideInfos } from '@components/My/Intro';
 
-const Section = styled.section`
-  width: 100%;
-  margin-top: 10px;
-  border-bottom: 1px solid #9e9e9e3d;
-`;
+const myCss = {
+  layout: css`
+    background-color: ${color.lightGrayBg};
+    padding: 0;
+    padding-top: 50px;
+    min-height: 100vh;
+  `,
+  wrap: css`
+    display: flex;
+    flex-direction: column;
+    background-color: ${color.lightGrayBg};
+  `,
+  section: css`
+    width: 100%;
+    margin-top: 10px;
+    border-bottom: 1px solid #9e9e9e3d;
+  `,
+  copyright: css`
+    padding: 30px 15px;
+    font-size: 14px;
+    color: ${color.darkGrayText};
+    display: flex;
+    justify-content: center;
+  `
+};
 
 const My = () => {
-  const infos = [
-    { name: '포인트', iconUrl: '/icon/point.png', linkUrl: '' },
-    { name: '쿠폰함', iconUrl: '/icon/coupon.png', linkUrl: '' },
-    { name: '선물함', iconUrl: '/icon/gift.png', linkUrl: '' },
-    { name: '찜', iconUrl: '/icon/like.png', linkUrl: '' },
-    { name: '주문내역', iconUrl: '/icon/order.png', linkUrl: '' },
-    { name: '리뷰관리', iconUrl: '/icon/review.png', linkUrl: '' }
-  ];
-
-  const sideInfos = [
-    { name: '공지사항', linkUrl: '' },
-    { name: '이벤트', linkUrl: '' },
-    { name: '고객센터', linkUrl: '' },
-    { name: '환경설정', linkUrl: '' },
-    { name: '약관 및 정책', linkUrl: '' }
-  ];
-
   //TODO: API 연동
   const userInfo = {
     nickname: '피카츄',
@@ -41,212 +41,24 @@ const My = () => {
   };
 
   return (
-    <Layout
-      footer={<></>}
-      title="My돌핀"
-      innerStyle={css`
-        background-color: ${color.lightGray};
-        padding-bottom: 0;
-        min-height: 100vh;
-      `}
-    >
-      <div
-        css={css`
-          display: flex;
-          flex-direction: column;
-          background-color: ${color.lightGray};
-        `}
-      >
-        <Section>
+    <Layout footer={<></>} title="My돌핀" innerStyle={myCss.layout}>
+      <div css={myCss.wrap}>
+        <section css={myCss.section}>
           <Profile
             nickname={userInfo.nickname}
             membership={userInfo.membership.name}
             profileUrl={userInfo.profileUrl}
           />
           <Membership name={userInfo.membership.name} imageUrl={userInfo.membership.imageUrl} />
-          <Infos infos={infos} />
-        </Section>
-        <Section>
-          <SideInfos sideInfos={sideInfos} />
-        </Section>
-        <div
-          css={css`
-            padding: 30px 15px;
-            font-size: 14px;
-            color: ${color.darkGray};
-            display: flex;
-            justify-content: center;
-          `}
-        >
-          Copyright Doooolphin in Seoul, All Rights Reserved
-        </div>
+          <Infos />
+        </section>
+        <section css={myCss.section}>
+          <SideInfos />
+        </section>
+        <div css={myCss.copyright}>Copyright Doooolphin in Seoul, All Rights Reserved</div>
       </div>
     </Layout>
   );
-};
-
-const Profile = ({ nickname, membership, profileUrl }) => (
-  <div
-    css={css`
-      display: flex;
-      align-items: center;
-      padding: 15px;
-      gap: 15px;
-      background-color: ${color.white};
-      margin-bottom: 2px;
-      cursor: pointer;
-      > span:first-of-type {
-        font-size: 20px;
-        strong {
-          color: ${color.darkGray};
-        }
-      }
-      > span:last-of-type {
-        position: absolute;
-        right: 15px;
-        font-size: 18px;
-        font-weight: 200;
-        color: ${color.darkGray};
-      }
-    `}
-  >
-    <div
-      css={css`
-        width: 60px;
-        height: 60px;
-        border-radius: 50%;
-        overflow: hidden;
-      `}
-    >
-      <img src={profileUrl} alt={`${nickname}님`} />
-    </div>
-    <span>
-      <strong>{membership}, </strong>
-      {nickname}
-    </span>
-    <span>
-      <RightOutlined />
-    </span>
-  </div>
-);
-
-Profile.propTypes = {
-  nickname: PropTypes.string,
-  membership: PropTypes.string,
-  profileUrl: PropTypes.string
-};
-
-const Membership = ({ name, imageUrl }) => (
-  <div
-    css={css`
-      display: flex;
-      padding: 5px 15px;
-      align-items: center;
-      justify-content: space-between;
-      background-color: ${color.white};
-      margin-bottom: 2px;
-      > span:first-of-type {
-        width: 200px;
-      }
-      > button {
-        background-color: #f6f6f6;
-        padding: 5px 10px;
-        border-radius: 25px;
-        height: 30px;
-        color: #505050;
-      }
-    `}
-  >
-    <span
-      css={css`
-        width: 200px;
-      `}
-    >
-      <img src={imageUrl} alt={`${name} 출두요~!`} />
-    </span>
-    <button>등급별 혜택</button>
-  </div>
-);
-
-Membership.propTypes = {
-  name: PropTypes.string,
-  imageUrl: PropTypes.string
-};
-
-const Infos = ({ infos }) => (
-  <div
-    css={css`
-      display: grid;
-      grid-template-columns: 1fr 1fr 1fr;
-      grid-gap: 1px;
-    `}
-  >
-    {infos.map((info) => (
-      <Link key={info.name} to={info.linkUrl}>
-        <div
-          css={css`
-            background-color: ${color.white};
-            display: flex;
-            flex-direction: column;
-            align-items: center;
-            padding: 15px;
-            gap: 5px;
-            span:first-of-type {
-              width: 40px;
-            }
-          `}
-        >
-          <span>
-            <img src={info.iconUrl} alt={info.name} />
-          </span>
-          <span>{info.name}</span>
-        </div>
-      </Link>
-    ))}
-  </div>
-);
-
-Infos.propTypes = {
-  infos: PropTypes.array
-};
-
-const SideInfos = ({ sideInfos }) => (
-  <div
-    css={css`
-      background-color: ${color.white};
-      > div:not(:last-of-type) {
-        border-bottom: 1px solid ${color.lightGray};
-      }
-    `}
-  >
-    {sideInfos.map((sideInfo) => (
-      <div
-        key={sideInfo.name}
-        css={css`
-          padding: 20px 15px;
-          cursor: pointer;
-          a > span:last-of-type {
-            position: absolute;
-            right: 15px;
-            font-size: 18px;
-            font-weight: 200;
-            color: ${color.darkGray};
-          }
-        `}
-      >
-        <Link to={sideInfo.linkUrl}>
-          <span>{sideInfo.name}</span>
-          <span>
-            <RightOutlined />
-          </span>
-        </Link>
-      </div>
-    ))}
-  </div>
-);
-
-SideInfos.propTypes = {
-  sideInfos: PropTypes.array
 };
 
 export default My;

--- a/src/pages/SignIn.jsx
+++ b/src/pages/SignIn.jsx
@@ -3,6 +3,7 @@ import Layout from '@components/Common/Layout';
 import styled from '@emotion/styled';
 import { useNavigate } from 'react-router-dom';
 import { useState } from 'react';
+import { css } from '@emotion/react';
 
 const HeadWrapper = styled.div`
   height: 400px;
@@ -98,7 +99,16 @@ const SignIn = () => {
     }
   };
   return (
-    <Layout inner={<></>} footer={false} title="로그인">
+    <Layout
+      inner={<></>}
+      footer={false}
+      title="로그인"
+      innerStyle={css`
+        display: flex;
+        flex-direction: column;
+        height: 100vh;
+      `}
+    >
       <Container>
         <HeadWrapper>
           <SubWrapper>

--- a/src/pages/SignUp/Agreement.jsx
+++ b/src/pages/SignUp/Agreement.jsx
@@ -5,6 +5,7 @@ import { RightOutlined } from '@ant-design/icons';
 import { useState } from 'react';
 import DefaultButton from '@components/Common/Button/DefaultButton';
 import { useNavigate } from 'react-router-dom';
+import { css } from '@emotion/react';
 
 const FootWrapper = styled.div`
   display: flex;
@@ -107,7 +108,15 @@ const SignUp = () => {
   };
 
   return (
-    <Layout footer={false} title="회원가입">
+    <Layout
+      footer={false}
+      title="회원가입"
+      innerStyle={css`
+        display: flex;
+        flex-direction: column;
+        height: 100vh;
+      `}
+    >
       <Container>
         <H1>
           반가워요! 가입하려면

--- a/src/stories/doolphin/Navigation.stories.jsx
+++ b/src/stories/doolphin/Navigation.stories.jsx
@@ -8,4 +8,4 @@ export default {
   }
 };
 
-export const Default = <Footer />;
+export const Default = () => <Footer />;

--- a/src/styles/common.js
+++ b/src/styles/common.js
@@ -1,11 +1,12 @@
 const color = {
   primary: '#AC4AC4',
-  darkGray: '#9e9e9e',
   lightgray: 'lightgray',
   white: '#ffffff',
   gray: 'gray',
   darkGray: '#555',
-  moreLigthGray: '#eee'
+  moreLigthGray: '#eee',
+  lightGrayBg: '#F9F9FA',
+  darkGrayText: '#9e9e9e'
 };
 
 const width = {


### PR DESCRIPTION
- 작업내용
  - 도메인별 컴포넌트 쪼개기
     components>My 폴더 생성
  - css 정리
     css prop 을 이용하여 정리 
     https://emotion.sh/docs/best-practices 참고
     
 - 추후 
     더 나아가 중복 되는 스타일들을 추가로 공통 css 처리하기 ( 플젝 전체 코드에 적용 )
     
 
emotion styled vs css prop 
두가지를 다 사용해보고 느낀점

두가지모두 만들어지는 코드의 양이나 사용할때 별 차이가 없음
하지만 작업하다보니 styled로 작업한건 단순 스타일링을 해놓은 컴포넌트인지, 비즈니스로직이 들어가있는 
하위 컴포넌트인지 한눈에 알아보기 어려움 ( 이는 네이밍룰 적용으로 해결이 가능하지만, 이름짓는데 시간이 더 들어갈수도..)
그리고 같은 스타일을 다른 태그에 적용하고 싶은 경우 css prop이 적합해보임 ( styled로는 여러벌을 작업해야함 )
리팩토링 코드 한번보고 용준쓰의 의견을 주면 styled랑 css prop 둘중 하나 확실히 정해서 나머지 컴포넌트 갈아 엎는걸로!


